### PR TITLE
Add SQLite persistence with SQLModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,13 @@ Remember, it's self-paced so feel free to take a break! ☕️
 
 ---
 
+## Running locally (with persistence)
+
+1. Install dependencies: `pip install -r requirements.txt`
+2. Optionally set a custom database location: `export DB_PATH="sqlite:///./data.db"`
+	- Defaults to a local SQLite file; `.gitignore` already excludes `*.sqlite`.
+3. Start the API: `uvicorn src.app:app --reload`
+	- Tables are created on startup and seeded once with the sample activities.
+
 &copy; 2025 GitHub &bull; [Code of Conduct](https://www.contributor-covenant.org/version/2/1/code_of_conduct/code_of_conduct.md) &bull; [MIT License](https://gh.io/mit)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+sqlmodel

--- a/src/app.py
+++ b/src/app.py
@@ -1,81 +1,167 @@
-"""
-High School Management System API
+"""High School Management System API with persistent storage."""
 
-A super simple FastAPI application that allows students to view and sign up
-for extracurricular activities at Mergington High School.
-"""
+from __future__ import annotations
 
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
 import os
 from pathlib import Path
+from typing import Dict
 
-app = FastAPI(title="Mergington High School API",
-              description="API for viewing and signing up for extracurricular activities")
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.responses import RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from sqlmodel import Field, Relationship, SQLModel, Session, create_engine, select
+
+app = FastAPI(
+    title="Mergington High School API",
+    description="API for viewing and signing up for extracurricular activities",
+)
 
 # Mount the static files directory
 current_dir = Path(__file__).parent
-app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
-          "static")), name="static")
+app.mount("/static", StaticFiles(directory=current_dir / "static"), name="static")
 
-# In-memory activity database
-activities = {
+DB_PATH = os.getenv("DB_PATH", "sqlite:///./data.db")
+connect_args = {"check_same_thread": False} if DB_PATH.startswith("sqlite") else {}
+engine = create_engine(DB_PATH, connect_args=connect_args)
+
+INITIAL_ACTIVITIES: Dict[str, Dict[str, object]] = {
     "Chess Club": {
         "description": "Learn strategies and compete in chess tournaments",
         "schedule": "Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+        "participants": ["michael@mergington.edu", "daniel@mergington.edu"],
     },
     "Programming Class": {
         "description": "Learn programming fundamentals and build software projects",
         "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
         "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+        "participants": ["emma@mergington.edu", "sophia@mergington.edu"],
     },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
         "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+        "participants": ["john@mergington.edu", "olivia@mergington.edu"],
     },
     "Soccer Team": {
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
         "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+        "participants": ["liam@mergington.edu", "noah@mergington.edu"],
     },
     "Basketball Team": {
         "description": "Practice and play basketball with the school team",
         "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+        "participants": ["ava@mergington.edu", "mia@mergington.edu"],
     },
     "Art Club": {
         "description": "Explore your creativity through painting and drawing",
         "schedule": "Thursdays, 3:30 PM - 5:00 PM",
         "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+        "participants": ["amelia@mergington.edu", "harper@mergington.edu"],
     },
     "Drama Club": {
         "description": "Act, direct, and produce plays and performances",
         "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
         "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"],
     },
     "Math Club": {
         "description": "Solve challenging problems and participate in math competitions",
         "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
         "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+        "participants": ["james@mergington.edu", "benjamin@mergington.edu"],
     },
     "Debate Team": {
         "description": "Develop public speaking and argumentation skills",
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
+        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"],
+    },
 }
+
+
+class ActivityParticipant(SQLModel, table=True):
+    activity_id: int = Field(foreign_key="activity.id", primary_key=True)
+    participant_id: int = Field(foreign_key="participant.id", primary_key=True)
+
+
+class Activity(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    name: str = Field(unique=True, index=True)
+    description: str
+    schedule: str
+    max_participants: int
+    participants: list["Participant"] = Relationship(
+        back_populates="activities", link_model=ActivityParticipant
+    )
+
+
+class Participant(SQLModel, table=True):
+    id: int | None = Field(default=None, primary_key=True)
+    email: str = Field(unique=True, index=True)
+    activities: list[Activity] = Relationship(
+        back_populates="participants", link_model=ActivityParticipant
+    )
+
+
+def create_db_and_tables() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+def seed_initial_data() -> None:
+    """Load starter activities only if the database is empty."""
+    with Session(engine) as session:
+        existing_activity = session.exec(select(Activity.id)).first()
+        if existing_activity:
+            return
+
+        for name, data in INITIAL_ACTIVITIES.items():
+            activity = Activity(
+                name=name,
+                description=data["description"],
+                schedule=data["schedule"],
+                max_participants=data["max_participants"],
+            )
+            session.add(activity)
+            session.commit()
+            session.refresh(activity)
+
+            for email in data["participants"]:
+                participant = session.exec(
+                    select(Participant).where(Participant.email == email)
+                ).first()
+                if participant is None:
+                    participant = Participant(email=email)
+                    session.add(participant)
+                    session.commit()
+                    session.refresh(participant)
+
+                activity.participants.append(participant)
+
+            session.add(activity)
+            session.commit()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    create_db_and_tables()
+    seed_initial_data()
+
+
+def get_session():
+    with Session(engine) as session:
+        yield session
+
+
+def activity_to_dict(activity: Activity) -> Dict[str, object]:
+    return {
+        "description": activity.description,
+        "schedule": activity.schedule,
+        "max_participants": activity.max_participants,
+        "participants": [participant.email for participant in activity.participants],
+    }
 
 
 @app.get("/")
@@ -84,49 +170,54 @@ def root():
 
 
 @app.get("/activities")
-def get_activities():
-    return activities
+def get_activities(session: Session = Depends(get_session)):
+    activities = session.exec(select(Activity).order_by(Activity.name)).all()
+    return {activity.name: activity_to_dict(activity) for activity in activities}
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+def signup_for_activity(
+    activity_name: str, email: str, session: Session = Depends(get_session)
+):
+    activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+    if activity is None:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
+    if any(participant.email == email for participant in activity.participants):
+        raise HTTPException(status_code=400, detail="Student is already signed up")
 
-    # Validate student is not already signed up
-    if email in activity["participants"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Student is already signed up"
-        )
+    participant = session.exec(select(Participant).where(Participant.email == email)).first()
+    if participant is None:
+        participant = Participant(email=email)
+        session.add(participant)
+        session.commit()
+        session.refresh(participant)
 
-    # Add student
-    activity["participants"].append(email)
+    activity.participants.append(participant)
+    session.add(activity)
+    session.commit()
+    session.refresh(activity)
+
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
-    if activity_name not in activities:
+def unregister_from_activity(
+    activity_name: str, email: str, session: Session = Depends(get_session)
+):
+    activity = session.exec(select(Activity).where(Activity.name == activity_name)).first()
+    if activity is None:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
-    activity = activities[activity_name]
-
-    # Validate student is signed up
-    if email not in activity["participants"]:
+    participant = session.exec(select(Participant).where(Participant.email == email)).first()
+    if participant is None or participant not in activity.participants:
         raise HTTPException(
-            status_code=400,
-            detail="Student is not signed up for this activity"
+            status_code=400, detail="Student is not signed up for this activity"
         )
 
-    # Remove student
-    activity["participants"].remove(email)
+    activity.participants.remove(participant)
+    session.add(activity)
+    session.commit()
+    session.refresh(activity)
+
     return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
## Summary
- replace in-memory activities with SQLModel-backed SQLite storage
- seed database once with existing sample activities and participants
- add run instructions and dependency for SQLModel

## Testing
- not run (not requested)